### PR TITLE
Add bat config to disable line numbers for easier text copying

### DIFF
--- a/.config/bat/config
+++ b/.config/bat/config
@@ -1,0 +1,1 @@
+--style=plain

--- a/.config/zsh-abbr/user-abbreviations
+++ b/.config/zsh-abbr/user-abbreviations
@@ -1,6 +1,5 @@
-abbr "bat"="bat --style=auto"
 abbr "br"="git branch"
-abbr "cat"="bat --style=auto"
+abbr "cat"="bat"
 abbr "cm"="git commit"
 abbr "co"="git checkout"
 abbr "fe"="git fetch -p"


### PR DESCRIPTION
- Create .config/bat/config with --style=plain
- Remove bat abbreviation and --style=auto from cat abbreviation (style is now centrally managed via bat config)

https://claude.ai/code/session_01CrJaYgV6bvH8KTMFjnZqKr