### PR TITLE
Deploy AI agent configs via rules-for-ai submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "rules-for-ai"]
 	path = rules-for-ai
 	url = https://github.com/hashiiiii/rules-for-ai.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rules-for-ai"]
+	path = rules-for-ai
+	url = https://github.com/hashiiiii/rules-for-ai.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ WHY-only notes for AI agents. WHAT is in [`README.md`](README.md) and [`mise.tom
 
 - **`mise bootstrap`** converges machine setup from `mise.toml`; `bootstrap.sh` only installs Homebrew + mise.
 - **`~/.config`** is a whole-directory symlink into this **public** repo — `.gitignore` denies secrets/runtime paths only.
-- **`~/.claude`** is not whole-directory symlinked (runtime/secrets); only `hooks/` lives here. Agent configs (settings, skills, MCP) come from [rules-for-ai](https://github.com/hashiiiii/rules-for-ai).
+- **`~/.claude`** is not whole-directory symlinked (runtime/secrets); only `hooks/` lives here. Agent configs (settings, skills, MCP) come from the [rules-for-ai](https://github.com/hashiiiii/rules-for-ai) **submodule**, symlinked by this repo's `mise.toml`.
 - **Brewfile** holds all Homebrew packages (mise brew backend does not cover casks / MAS).
 - **No zsh plugin manager** — plugins are brew formulae sourced in `.zshrc`.
 - **`.zprofile`** = login env/PATH; **`.zshrc`** = interactive shell.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,20 @@ Use your `DOTFILE_DIR` if you chose a non-default location.
 
 ## AI agent configs
 
-Claude Code / cursor-agent configs live in
-[rules-for-ai](https://github.com/hashiiiii/rules-for-ai) and deploy
-themselves:
+Claude Code / cursor-agent configs come from the
+[rules-for-ai](https://github.com/hashiiiii/rules-for-ai) submodule and are
+symlinked into `~/.claude` / `~/.cursor` by this repo's `mise.toml`:
 
 ```bash
-git clone https://github.com/hashiiiii/rules-for-ai.git ~/workspace/rules-for-ai
-cd ~/workspace/rules-for-ai && mise dotfiles apply
+git submodule update --init
+mise dotfiles apply
+```
+
+To pick up a newer rules-for-ai:
+
+```bash
+git submodule update --remote rules-for-ai
+git add rules-for-ai && git commit -m "chore: bump rules-for-ai"
 ```
 
 Setup: [`mise.toml`](mise.toml)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,7 +36,7 @@ if [ -d "$DOTFILE_DIR/.git" ]; then
 else
   info "Cloning into $DOTFILE_DIR..."
   mkdir -p "$(dirname "$DOTFILE_DIR")"
-  git clone "$REPO_URL" "$DOTFILE_DIR"
+  git clone --recurse-submodules "$REPO_URL" "$DOTFILE_DIR"
 fi
 
 # Pre-apply dotfiles so the global ~/.config/mise/config.toml ([tools]) is in place before
@@ -44,6 +44,8 @@ fi
 cd "$DOTFILE_DIR"
 info "Trusting mise config..."
 mise trust
+info "Initializing submodules..."
+git -C "$DOTFILE_DIR" submodule update --init
 info "Applying dotfiles..."
 mise dotfiles apply --yes
 info "Running mise bootstrap..."

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,14 @@ experimental = true
 "~/.zshrc"    = ".zshrc"
 "~/.zprofile" = ".zprofile"
 "~/.claude/hooks"         = ".config/claude/hooks"
+# AI agent configs from the rules-for-ai submodule. One skills source feeds
+# both harnesses (Claude Code and cursor-agent read SKILL.md).
+"~/.claude/CLAUDE.md"             = "rules-for-ai/AGENTS.md"
+"~/.claude/settings.json"         = "rules-for-ai/claude/settings.json"
+"~/.claude/statusline-command.sh" = "rules-for-ai/claude/statusline-command.sh"
+"~/.claude/skills"                = "rules-for-ai/skills"
+"~/.cursor/skills"                = "rules-for-ai/skills"
+"~/.cursor/mcp.json"              = "rules-for-ai/cursor/mcp.json"
 "~/Library/Developer/Xcode/UserData/FontAndColorThemes/tokyo-night.xccolortheme" = ".config/xcode/tokyo-night.xccolortheme"
 
 # Curated sections: semantic keys mise maps to canonical defaults writes.
@@ -37,6 +45,7 @@ login_shell = "/bin/zsh"
 
 [tasks.bootstrap]
 run = [
+  "git -C {{config_root}} submodule update --init",
   "brew bundle --file={{config_root}}/Brewfile",
   "pre-commit install --install-hooks",
 ]

--- a/mise.toml
+++ b/mise.toml
@@ -37,6 +37,9 @@ tap_to_click = true
 "com.apple.dock"          = { tilesize = 52.0 }
 "com.apple.WindowManager" = { EnableStandardClickToShowDesktop = false }
 
+[bootstrap.hooks.pre-dotfiles]
+run = "git -C {{config_root}} submodule update --init"
+
 [bootstrap.hooks.post-defaults]
 run = "killall Finder SystemUIServer Dock || true"
 


### PR DESCRIPTION
## Summary

Follow-up to #7 — global deployment of AI agent configs moves into this repo, referencing [rules-for-ai](https://github.com/hashiiiii/rules-for-ai) as a submodule (pinned to the head of its open refresh PR; bump after it merges).

- Add `rules-for-ai` submodule at the repo root
- `mise.toml`: six `[dotfiles]` mappings sourcing from the submodule (`~/.claude/CLAUDE.md`, `settings.json`, `statusline-command.sh`, `skills` x2, `~/.cursor/mcp.json`); bootstrap now runs `git submodule update --init` first
- Update AGENTS.md / README wording: rules-for-ai no longer deploys itself; this repo does

## Verification

- `mise dotfiles apply` on this machine: all six targets re-pointed into `dotfiles/rules-for-ai/`; `~/.claude/hooks` unchanged
- `claude -p` smoke test passes; `cursor-agent --list-models` works
- Submodule pin verified to contain the portable layout (no `mise.toml`, no `docs/`)

## Merge order

Merge rules-for-ai PR #1 before (or right after) this PR, and only run the submodule bump flow after PR #1 is merged — until then rules-for-ai's main still has the legacy tree and `git submodule update --remote` would pin a tree whose sources don't exist (apply fails safely, but the bad gitlink could get committed).